### PR TITLE
Use correct path separator on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Vurich <jackefransham@hotmail.co.uk>"]
 description = "Crunchy unroller: deterministically unroll constant loops"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,4 +33,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(target_os = "windows")]
+include!(concat!(env!("OUT_DIR"), "\\lib.rs"));
+
+#[cfg(not(target_os = "windows"))]
 include!(concat!(env!("OUT_DIR"), "/lib.rs"));


### PR DESCRIPTION
@Vurich This crate is used as part of `libsecp256k1`, we have a CI setup that also tests Windows as a target and the CI unfortunately fails due to the wrong path separator. Would be great if you could take a look at this PR and publish a new version.