### PR TITLE
Fix cross-compilation between windows and non-windows.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -250,4 +250,6 @@ mod tests {{
 "#, limit).as_str());
 
     f.write_all(output.as_bytes()).unwrap();
+
+    println!("cargo:rustc-env=CRUNCHY_LIB_SUFFIX={}lib.rs", std::path::MAIN_SEPARATOR);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,5 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(target_os = "windows")]
-include!(concat!(env!("OUT_DIR"), "\\lib.rs"));
+include!(concat!(env!("OUT_DIR"), env!("CRUNCHY_LIB_SUFFIX")));
 
-#[cfg(not(target_os = "windows"))]
-include!(concat!(env!("OUT_DIR"), "/lib.rs"));


### PR DESCRIPTION
Formerly, src/lib.rs used `cfg(target_os=..)` to tell which separator to use for `env!(OUT_DIR)` and `lib.rs`. But `target_os` only tells you which OS you're building for, not which OS you're building on: and Rust's `include`! interprets paths from the point of view of the _host_ OS.

With this patch, the build script now exposes an environment variable to tell `src/lib.rs` which separator to use.

(We can't use `std::path::MAIN_SEPARATOR` directly in `src/lib.rs`, since `concat!` doesn't accept it as an input.)

This should fix issue #15.